### PR TITLE
Chore: Add markdown link validation pre-commit hooks

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,20 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^mailto:"
+        },
+        {
+            "pattern": "^#"
+        }
+    ],
+    "replacementPatterns": [],
+    "httpHeaders": [],
+    "timeout": "5s",
+    "retryOn429": true,
+    "retryCount": 3,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [
+        200,
+        206
+    ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,9 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.12.2
+    hooks:
+      - id: markdown-link-check
+        args: ['--config', '.markdown-link-check.json']
+        types: [markdown]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,5 +17,18 @@ pytest tests/ -v
 - Type hints required
 - Async-first design
 
+## Pre-Commit Hooks (Required)
+
+All developers **must** install and run pre-commit hooks before committing. This ensures:
+- All markdown links are validated
+- Code quality (Ruff) is enforced
+
+### Setup
+
+```bash
+uv pip install pre-commit
+pre-commit install
+```
+
 ## License
 MIT


### PR DESCRIPTION
Add pre-commit hooks to validate markdown links across the repository. Standardizes documentation quality gates.